### PR TITLE
Fix GMT toggle persistence and row highlighting

### DIFF
--- a/src/components/gmtAdjuster.js
+++ b/src/components/gmtAdjuster.js
@@ -1,26 +1,22 @@
 export function gmtAdjuster() {
 
     const gmtToggle = document.getElementById("gmtToggle");
-//const tableBody = document.getElementById("tableBody");
 
-// Function to update the class based on the toggle state
-function cacheBasedOnToggle(isGmtPlus2) {
-    if (isGmtPlus2) {
-        //tableBody.classList = "h-12-system";
-        localStorage.setItem("isGmtPlus2", "1"); // Save to localStorage
-    } else {
-        //tableBody.classList = "h-24-system";
-        localStorage.setItem("isGmtPlus2", "0"); // Save to localStorage
+    // Save the choice in `localStorage`
+    function cacheBasedOnToggle(isGmtPlus2) {
+        if (isGmtPlus2) {
+            localStorage.setItem("isGmtPlus2", "1");
+        } else {
+            localStorage.setItem("isGmtPlus2", "0");
+        }
     }
-}
 
-// Event listener for the toggle change
-gmtToggle.addEventListener("change", () => {
-    cacheBasedOnToggle(gmtToggle.checked);
-});
+    // Event listener for the toggle change
+    gmtToggle.addEventListener("change", () => {
+        cacheBasedOnToggle(gmtToggle.checked);
+    });
 
-// Check `localStorage` on page load and set the initial state
-window.addEventListener("DOMContentLoaded", () => {
+    // Set the initial state from `localStorage`
     const savedFormat = localStorage.getItem("isGmtPlus2");
     if (savedFormat === "1") {
         gmtToggle.checked = true;
@@ -29,6 +25,5 @@ window.addEventListener("DOMContentLoaded", () => {
         gmtToggle.checked = false;
         cacheBasedOnToggle(false);
     }
-});  
 }
 

--- a/src/components/salatManager.js
+++ b/src/components/salatManager.js
@@ -43,6 +43,7 @@ function convertTo12Hour(time24) {
 // Function to generate rows dynamically
 function generateTableRows() {
     tableBody.innerHTML = "";
+    currentHighlitedPrayerElement = null;
 
     for (let i = 0; i < todayTimes.length; i++) {
         // Create a new row

--- a/src/main.js
+++ b/src/main.js
@@ -15,9 +15,9 @@ import { gmtAdjuster } from './components/gmtAdjuster';
 
 darkMode();
 backgroundManager();
+gmtAdjuster();
 salatManager();
 hourMode();
-gmtAdjuster();
 bigFont();
 
 


### PR DESCRIPTION
## Summary
- ensure gmt toggle state is applied before generating rows
- reset highlighted row when rebuilding the table
- load saved GMT option without waiting for `DOMContentLoaded`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c33403488324921eb982c3d2cba3